### PR TITLE
Улучшение EVA скафандра Синдиката

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Head/eva-helmets.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/eva-helmets.yml
@@ -37,6 +37,13 @@
     sprite: Clothing/Head/Helmets/eva_syndicate.rsi
   - type: Clothing
     sprite: Clothing/Head/Helmets/eva_syndicate.rsi
+  - type: Armor # DS14
+    modifiers:
+      coefficients:
+        Blunt: 0.9
+        Slash: 0.9
+        Piercing: 0.9
+        Heat: 0.9
 
 #Cosmonaut Helmet
 - type: entity

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/softsuits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/softsuits.yml
@@ -26,6 +26,18 @@
     sprite: Clothing/OuterClothing/Suits/eva_syndicate.rsi
   - type: Clothing
     sprite: Clothing/OuterClothing/Suits/eva_syndicate.rsi
+  - type: Armor # DS14
+    modifiers:
+      coefficients:
+        Blunt: 0.70
+        Slash: 0.70
+        Piercing: 0.70 
+        Heat: 0.80
+  - type: ExplosionResistance # DS14
+    damageCoefficient: 0.90 
+  - type: ClothingSpeedModifier # DS14
+    walkModifier: 0.9
+    sprintModifier: 0.9
   - type: Tag
     tags:
     - SuitEVA

--- a/Resources/Prototypes/Entities/Clothing/OuterClothing/softsuits.yml
+++ b/Resources/Prototypes/Entities/Clothing/OuterClothing/softsuits.yml
@@ -26,18 +26,20 @@
     sprite: Clothing/OuterClothing/Suits/eva_syndicate.rsi
   - type: Clothing
     sprite: Clothing/OuterClothing/Suits/eva_syndicate.rsi
-  - type: Armor # DS14
+  # DS14-start
+  - type: Armor
     modifiers:
       coefficients:
         Blunt: 0.70
         Slash: 0.70
         Piercing: 0.70 
         Heat: 0.80
-  - type: ExplosionResistance # DS14
+  - type: ExplosionResistance
     damageCoefficient: 0.90 
-  - type: ClothingSpeedModifier # DS14
+  - type: ClothingSpeedModifier
     walkModifier: 0.9
     sprintModifier: 0.9
+  # DS14-end
   - type: Tag
     tags:
     - SuitEVA


### PR DESCRIPTION
## Описание PR
Как и договаривались, взамен на становление контрабандой, синдиева получила улучшение характеристик.

## Изменения для патчноута
* Кроваво-красная EVA теперь предоставляет защиту уровня стандартного обмундирования СБ. Замедление уменьшено с 20% до 10%.

## Критические изменения
Нет.
