### PR TITLE
Суффиксы для ящиков синдиката

### DIFF
--- a/Resources/Locale/ru-RU/ss14-ru/prototypes/catalog/fills/crates/syndicate.ftl
+++ b/Resources/Locale/ru-RU/ss14-ru/prototypes/catalog/fills/crates/syndicate.ftl
@@ -1,7 +1,9 @@
 ent-CrateSyndicateSurplusBundle = ящик Синдиката
     .desc = Стальной ящик тёмного цвета с красными полосами и выдавленной на передней панели логотипом Синдиката.
+    .suffix = Припасы
 ent-CrateCybersunJuggernautBundle = { ent-CrateSyndicate }
     .desc = { ent-CrateSyndicate.desc }
     .suffix = Набор джаггернаута Cybersun
 ent-CrateSyndicateSuperSurplusBundle = { ent-CrateSyndicate }
     .desc = { ent-CrateSyndicate.desc }
+    .suffix = Суперприпасы

--- a/Resources/Prototypes/Catalog/Fills/Crates/syndicate.yml
+++ b/Resources/Prototypes/Catalog/Fills/Crates/syndicate.yml
@@ -3,7 +3,6 @@
   parent: [ CrateSyndicate, StorePresetUplink, BaseSyndicateContraband ]
   name: Syndicate surplus crate
   description: Contains 50 telecrystals worth of completely random Syndicate items. It can be useless junk or really good.
-  suffix: Припасы
   components:
     - type: SurplusBundle
       totalPrice: 50
@@ -28,7 +27,6 @@
   parent: [ CrateSyndicate, StorePresetUplink, BaseSyndicateContraband ]
   name: Syndicate super surplus crate
   description: Contains 125 telecrystals worth of completely random Syndicate items.
-  suffix: Суперприпасы
   components:
     - type: SurplusBundle
       totalPrice: 125

--- a/Resources/Prototypes/Catalog/Fills/Crates/syndicate.yml
+++ b/Resources/Prototypes/Catalog/Fills/Crates/syndicate.yml
@@ -3,7 +3,7 @@
   parent: [ CrateSyndicate, StorePresetUplink, BaseSyndicateContraband ]
   name: Syndicate surplus crate
   description: Contains 50 telecrystals worth of completely random Syndicate items. It can be useless junk or really good.
-  suffix: Припасы Синдиката
+  suffix: Припасы
   components:
     - type: SurplusBundle
       totalPrice: 50
@@ -28,7 +28,7 @@
   parent: [ CrateSyndicate, StorePresetUplink, BaseSyndicateContraband ]
   name: Syndicate super surplus crate
   description: Contains 125 telecrystals worth of completely random Syndicate items.
-  suffix: Суперприпасы Синдиката
+  suffix: Суперприпасы
   components:
     - type: SurplusBundle
       totalPrice: 125

--- a/Resources/Prototypes/Catalog/Fills/Crates/syndicate.yml
+++ b/Resources/Prototypes/Catalog/Fills/Crates/syndicate.yml
@@ -3,6 +3,7 @@
   parent: [ CrateSyndicate, StorePresetUplink, BaseSyndicateContraband ]
   name: Syndicate surplus crate
   description: Contains 50 telecrystals worth of completely random Syndicate items. It can be useless junk or really good.
+  suffix: Припасы Синдиката
   components:
     - type: SurplusBundle
       totalPrice: 50
@@ -27,6 +28,7 @@
   parent: [ CrateSyndicate, StorePresetUplink, BaseSyndicateContraband ]
   name: Syndicate super surplus crate
   description: Contains 125 telecrystals worth of completely random Syndicate items.
+  suffix: Суперприпасы Синдиката
   components:
     - type: SurplusBundle
       totalPrice: 125


### PR DESCRIPTION
## Описание PR
Ящикам синдиката добавлен ранее отсутствующий суффикс, для более удобного поиска.

![Desktop_250105_0639](https://github.com/user-attachments/assets/9ee2803c-f3b5-41d9-9478-4d8e9d0b2051)
![Desktop_250105_0755](https://github.com/user-attachments/assets/a73daf09-4381-4136-a718-50163e0c5e03)

## Изменения для патчноута
Нет.

## Критические изменения
Нет.
