### PR TITLE
Теперь у ведущего утилизатора в кпк есть астронав

### DIFF
--- a/Resources/Prototypes/Entities/Objects/Devices/pda.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/pda.yml
@@ -1303,6 +1303,13 @@
     accentVColor: "#62237F"
   - type: Icon
     state: pda-seniorminer
+  - type: CartridgeLoader
+    uiKey: enum.PdaUiKey.Key
+    preinstalled:
+      - CrewManifestCartridge
+      - NotekeeperCartridge
+      - NewsReaderCartridge
+      - AstroNavCartridge
 
 - type: entity
   parent: BasePDA


### PR DESCRIPTION
## Описание PR
Небольшой фикс, в котором ведущему утилизатору в кпк добавил программу астронав (показывает координаты если взять кпк в руки). Интересно, так как у обычных утилей она была, а у ведущего нет. Большой ли смысл писать это в патчноут?

## Изменения для патчноута
- У ведущего утилизатора в КПК появилась программа Астронав.

## Критические изменения
Нема