### PR TITLE
Добавлена возможность выбирать причёску мольке.

### DIFF
--- a/Resources/Prototypes/Species/moth.yml
+++ b/Resources/Prototypes/Species/moth.yml
@@ -18,6 +18,7 @@
   sprites:
     Head: MobMothHead
     Snout: MobHumanoidAnyMarking
+    Hair: MobHumanoidAnyMarking
     Chest: MobMothTorso
     HeadTop: MobHumanoidAnyMarking
     HeadSide: MobHumanoidAnyMarking
@@ -40,10 +41,9 @@
 
 - type: markingPoints
   id: MobMothMarkingLimits
-  onlyWhitelisted: true
   points:
     Hair:
-      points: 0
+      points: 1
       required: false
     FacialHair:
       points: 0


### PR DESCRIPTION
## Описание PR
Добавлена возможность выбора причёски в меню кастомизации ниана. Убрано требование вайтлиста в кастомизации (не понял на что оно влияет - на локалке новых вариантов не появилось, на мапперском тоже, а если оно есть - обычные волосы вне вайтлиста молей).

## Изменения для патчноута
* Теперь нианы могут иметь стильные причёски!

## Критические изменения
Нет.