### PR TITLE
Шлем скафандра эскадрона теперь в чёрном списке хамелеона

### DIFF
--- a/Resources/Prototypes/Entities/Clothing/Head/hardsuit-helmets.yml
+++ b/Resources/Prototypes/Entities/Clothing/Head/hardsuit-helmets.yml
@@ -706,6 +706,8 @@
         Heat: 0.80
         Radiation: 0.80
         Caustic: 0.95
+  - type: Tag
+    tags: [] # ignore "WhitelistChameleon" tag
 
 #MISC. HARDSUITS
 #Clown Hardsuit


### PR DESCRIPTION
## Описание PR
Все вещи эскадрона смерти в хамелеоне находятся в чёрном списке, то есть их нельзя использовать, за исключением шлема скафандра, который там почему-то остался. Написали об этом в канале Баги ([ссылка](https://discord.com/channels/1030160796401016883/1332325468829122571)). Конечно это не очень страшый баг, но почему бы и не исправить. Не вижу большого смысла писать это в патчноут

## Изменения для патчноута
Нет

## Критические изменения
Нет
