### PR TITLE
Исправление железного подноса

### DIFF
--- a/Resources/Prototypes/_ADT/Entities/Objects/Misc/iron_tray.yml
+++ b/Resources/Prototypes/_ADT/Entities/Objects/Misc/iron_tray.yml
@@ -4,18 +4,25 @@
   name: железный поднос
   description: Поднос для разноса еды и напитков.
   components:
-  - type: Sprite
-    sprite: ADT/Objects/Misc/iron_tray.rsi
-    state: icon
-  - type: Storage
-    grid:
-    - 0,0,5,3
-  - type: Item
-    size: Normal
-  - type: UseDelay
-  - type: MeleeWeapon
-    damage:
-      types:
-        Blunt: 8
-    soundHit:
-      path: "/Audio/Weapons/smash.ogg"
+    - type: Sprite
+      sprite: ADT/Objects/Misc/iron_tray.rsi
+      state: icon
+    - type: Storage
+      maxItemSize: Normal
+      grid:
+        - 0,0,5,3
+      whitelist:
+        components:
+          - Food
+          - Utensil
+    - type: Item
+      size: Normal
+      shape:
+        - 0,0,2,1
+    - type: UseDelay
+    - type: MeleeWeapon
+      damage:
+        types:
+          Blunt: 8
+      soundHit:
+        path: "/Audio/Weapons/smash.ogg"


### PR DESCRIPTION
## Описание PR
Увеличен размер подноса (2х3), добавлен вайтлист на еду и столовые приборы (во избежание абуза внутреннего размера соразмерного рюкзаку), увеличен максимально возможный размер предмета внутри (теперь внутрь можно класть пиццу).

## Изменения для патчноута
* Исправление железного подноса.

## Критические изменения
Нет.
