### PR TITLE
Убран МГЛ у лидера ОБР

### DIFF
--- a/Resources/Prototypes/_DeadSpace/Roles/Jobs/CentComm/emergencyresponseteam.yml
+++ b/Resources/Prototypes/_DeadSpace/Roles/Jobs/CentComm/emergencyresponseteam.yml
@@ -129,7 +129,6 @@
     pocket2: DoorRemoteAll
   storage:
     back:
-    - WeaponSniperHristov
     - ERTloadoutGammaPrimary
     - ERTloadoutGammaSecondary
     - PinpointerNuclear

--- a/Resources/Prototypes/_DeadSpace/Roles/Jobs/CentComm/emergencyresponseteam.yml
+++ b/Resources/Prototypes/_DeadSpace/Roles/Jobs/CentComm/emergencyresponseteam.yml
@@ -129,7 +129,7 @@
     pocket2: DoorRemoteAll
   storage:
     back:
-    - WeaponLauncherMGL
+    - WeaponSniperHristov
     - ERTloadoutGammaPrimary
     - ERTloadoutGammaSecondary
     - PinpointerNuclear


### PR DESCRIPTION
## Описание PR
У лидера ОБР больше нет МГЛа. Вся операция не должна зависеть от скилла одного человека. К тому же, калят ситуации, когда при той же революции этот МГЛ отбирают. Зачем тогда давали?

По поводу христова я всё же передумав.
Пусть лидер пока будет человеком с более крепким скафандром и правом приказывать другим ОБРовцам. Как появятся портативные голопады, станет крутым связистом, передающим приказы от ЦК другим офицерам.

Возможно когда-нибудь у лидера появятся перчатки с аркалисом, чтобы хоть как-то быть лучше рядового солдата в бою. Или другая крутая фича...

## Изменения для патчноута
* Гранатомёт MGL убран из стандартной экипировки лидера ОБР "Гамма".

## Критические изменения
Нет.
