### PR TITLE
Исправление бага с сеткой

### DIFF
--- a/Resources/Prototypes/Recipes/Construction/Graphs/structures/fence_metal.yml
+++ b/Resources/Prototypes/Recipes/Construction/Graphs/structures/fence_metal.yml
@@ -9,7 +9,6 @@
     - to: straight
       completed:
       - !type:SnapToGrid
-        southRotation: true
       steps:
       - material: MetalRod
         amount: 5
@@ -17,7 +16,6 @@
     - to: corner
       completed:
       - !type:SnapToGrid
-        southRotation: true
       steps:
       - material: MetalRod
         amount: 5
@@ -25,7 +23,6 @@
     - to: end
       completed:
       - !type:SnapToGrid
-        southRotation: true
       steps:
       - material: MetalRod
         amount: 5
@@ -33,7 +30,6 @@
     - to: gate
       completed:
       - !type:SnapToGrid
-        southRotation: true
       steps:
       - material: MetalRod
         amount: 5


### PR DESCRIPTION
## Описание PR
Исправление довольно старой проблемы, связанной с тем, что при крафте сетки, если размещать её по горизонтали, то она всё равно ставилась по вертикали, что не очень круто. Написали об этом в канале баги ([ссылка](https://discord.com/channels/1030160796401016883/1333468008143655024)), как-то так

## Изменения для патчноута
- Исправлен баг с сеткой-рябицей, теперь её можно нормально крафтить.

## Критические изменения
нема
