### PR TITLE
Исправление набора автомата дена

### DIFF
--- a/Resources/Prototypes/_Backmen/Catalog/VendingMachines/DiscountsDan_catalog.yml
+++ b/Resources/Prototypes/_Backmen/Catalog/VendingMachines/DiscountsDan_catalog.yml
@@ -1,0 +1,77 @@
+- type: listing
+  id: DiscountDansInventory1
+  productEntity: FoodSnackCheesie
+  cost:
+    SpaceCash: 15
+  categories:
+    - DiscountDansInventory
+  conditions:
+    - !type:ListingLimitedStockCondition
+      stock: 15
+
+- type: listing
+  id: DiscountDansInventory2
+  productEntity: FoodSnackChips
+  cost:
+    SpaceCash: 15
+  categories:
+    - DiscountDansInventory
+  conditions:
+    - !type:ListingLimitedStockCondition
+      stock: 15
+
+- type: listing
+  id: DiscountDansInventory3
+  productEntity: FoodSnackBoritos
+  cost:
+    SpaceCash: 15
+  categories:
+    - DiscountDansInventory
+  conditions:
+    - !type:ListingLimitedStockCondition
+      stock: 15
+
+- type: listing
+  id: DiscountDansInventory4
+  productEntity: DrinkEnergyDrinkCan
+  cost:
+    SpaceCash: 15
+  categories:
+    - DiscountDansInventory
+  conditions:
+    - !type:ListingLimitedStockCondition
+      stock: 15
+
+- type: listing
+  id: DiscountDansInventory5
+  productEntity: FoodSnackPopcorn
+  cost:
+    SpaceCash: 15
+  categories:
+    - DiscountDansInventory
+  conditions:
+    - !type:ListingLimitedStockCondition
+      stock: 15
+
+- type: listing
+  id: DiscountDansInventory6
+  productEntity: FoodSnackEnergy
+  cost:
+    SpaceCash: 15
+  categories:
+    - DiscountDansInventory
+  conditions:
+    - !type:ListingLimitedStockCondition
+      stock: 15
+
+- type: listing
+  id: DiscountDansInventory7
+  productEntity: CigPackMixed
+  cost:
+    SpaceCash: 15
+  categories:
+    - DiscountDansInventory
+  conditions:
+    - !type:ListingLimitedStockCondition
+      stock: 15
+


### PR DESCRIPTION
## Описание PR
В этом пре добавил каталог для автомата дена, так как раньше отображался просто чёрный экран... всё по 15 кредитов, вроде нормально. Написали об этом в канале баги ([ссылка](https://discord.com/channels/1030160796401016883/1339227797729574994))

## Изменения для патчноута
- Исправлен автомат с закусками Дена, теперь ассортимент нормально отображается.

## Критические изменения
нема
