### PR TITLE
РСУ для инженера ОБР Эмбер

### DIFF
--- a/Resources/Prototypes/_DeadSpace/Roles/Jobs/CentComm/emergencyresponseteam.yml
+++ b/Resources/Prototypes/_DeadSpace/Roles/Jobs/CentComm/emergencyresponseteam.yml
@@ -459,6 +459,8 @@
     - ERTloadoutAmberSecondary
     - ERTloadoutAmberPrimary
     - Flare
+    - RCD
+    - RCDAmmo
 
 ## Red
 - type: job


### PR DESCRIPTION
## Описание PR
Сейчас у инженера нет начальных предметов для строительства/перестройки/сноса чего-либо. 
Раз он инженер, а визарды расщедрились на рсу в каждый шкаф для станционных инженеров, пускай будет.

## Изменения для патчноута
* Инженеру ОБР "Эмбер" добавлено РСУ. 

## Критические изменения
Нет.