### PR TITLE
Лёгкая переработка боргов

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
+++ b/Resources/Prototypes/Entities/Mobs/Cyborgs/base_borg_chassis.yml
@@ -73,12 +73,18 @@
       # Only used for NT borgs that can switch type, defined here to avoid copy-pasting the rest of this component.
       enum.BorgSwitchableTypeUiKey.SelectBorgType:
         type: BorgSelectTypeUserInterface
+      enum.StationMapUiKey.Key:
+        type: StationMapBoundUserInterface
+        requireInputValidation: false
   - type: ActivatableUI
     key: enum.BorgUiKey.Key
   - type: SiliconLawBound
   - type: ActionGrant
     actions:
-    - ActionViewLaws
+      - ActionViewLaws
+      - ActionPAIOpenMap #DS14
+  - type: StationMap #DS14
+  - type: Magboots #DS14
   - type: EmagSiliconLaw
     stunTime: 5
   - type: SiliconLawProvider
@@ -134,7 +140,7 @@
   # TODO: refactor movement to just be based on toggle like speedboots but for the boots themselves
   # TODO: or just have sentient speedboots be fast idk
   - type: PowerCellDraw
-    drawRate: 0.6
+    drawRate: 0.8
   # no ToggleCellDraw since dont want to lose access when power is gone
   - type: ItemSlots
     slots:
@@ -173,6 +179,7 @@
   - type: LockedWiresPanel
   - type: Damageable
     damageContainer: Silicon
+    damageModifierSet: StandardBorg
   - type: Destructible
     thresholds:
     - trigger:
@@ -333,6 +340,9 @@
       Unsexed: UnisexSiliconSyndicate
   - type: PointLight
     color: "#dd200b"
+  - type: Damageable
+    damageContainer: Silicon
+    damageModifierSet: CombatBorg
 
 - type: entity
   id: BaseBorgChassisDerelict

--- a/Resources/Prototypes/_DeadSpace/Demons/modifier_sets.yml
+++ b/Resources/Prototypes/_DeadSpace/Demons/modifier_sets.yml
@@ -21,3 +21,19 @@
     Heat: 0.2
     Poison: 0.25
     Radiation: 0
+
+- type: damageModifierSet
+  id: StandardBorg
+  coefficients:
+    Blunt: 0.8
+    Slash: 0.8
+    Piercing: 0.8
+    Heat: 0.9
+
+- type: damageModifierSet
+  id: CombatBorg
+  coefficients:
+    Blunt: 0.6
+    Slash: 0.6
+    Piercing: 0.6
+    Heat: 0.7


### PR DESCRIPTION
## Описание PR
Добавлена возможность просмотра карты (предложка), добавлены встроенные магнитные ботинки, взамен на чуть более быструю разрядку (0.6->0.8), добавлены резисты обычным боргам и боргам синдиката (СБ борг уже обладает своими резистами, их не менял), структурный урон по ним остался прежним, но теперь они не умирают с 4 пуль МК.

## Изменения для патчноута
* Добавлена кнопка просмотра карты боргам.
* Добавлены встроенные магнитные ботинки, которые слегка ускоряют разряд батареи.
* Теперь борги имеют резисты - небольшие у обычных и достаточно значимые у боевых.

## Критические изменения
Нет.